### PR TITLE
readme: make the helm command compatible with zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ disabled](https://cert-manager.io/docs/concepts/certificaterequest/#approver-con
 This can be done via helm using:
 
 ```bash
-$ helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager --set extraArgs={--controllers='*\,-certificaterequests-approver'} --set installCRDs=true --create-namespace
+$ helm upgrade -i -n cert-manager cert-manager jetstack/cert-manager --set extraArgs="{--controllers=*\,-certificaterequests-approver}" --set installCRDs=true --create-namespace
 ```
 
 Next, install policy-approver:


### PR DESCRIPTION
The { and } have a different meaning between bash and zsh, let's
quote the entire blob.