### PR TITLE
Allow loading of external evaluators

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,39 @@ spec:
     minSize: # 2048
     maxSize: # 2048
 ```
+
+
+# Custom Evaluators
+
+It's possible to add custom evaluator logic. This logic should be added to a
+new package.
+
+First, create a new package with a function to perform evaluation. This takes a
+`CertificateRequestPolicy` and a `CertificateRequest`.
+
+It must return three values:
+* a boolean approve/deny value (return true to approve a `CertificateRequest`)
+* a string message explaining the decision (can be blank)
+* an error representing any evaluation issues that should be retried (optional)
+
+```go
+func myEvaluateFunction(policy *cmpolicy.CertificateRequestPolicy, cr *cmapi.CertificateRequest) (bool, string, error) {
+	...
+}
+```
+
+Next, import your new package with a blank identifier:
+
+```go
+# main.go
+_ "github.com/ORG/policy-approver/pkg/policy/PACKAGE"
+```
+
+Finally, create an `init` function to load your package into the policy evaluation
+for the approver.
+
+```go
+func init() {
+	policy.Load(myEvaluateFunction)
+}
+```

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -46,12 +46,13 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			log := opts.Log
 
 			mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-				Scheme:                 api.Scheme,
-				MetricsBindAddress:     opts.MetricsAddress,
-				HealthProbeBindAddress: opts.ProbeAddress,
-				LeaderElection:         true,
-				LeaderElectionID:       "policy.cert-manager.io",
-				Logger:                 log,
+				Scheme:                  api.Scheme,
+				MetricsBindAddress:      opts.MetricsAddress,
+				HealthProbeBindAddress:  opts.ProbeAddress,
+				LeaderElectionNamespace: opts.LeaderElectionNamespace,
+				LeaderElection:          true,
+				LeaderElectionID:        "policy.cert-manager.io",
+				Logger:                  log,
 			})
 			if err != nil {
 				log.Error(err, "unable to start manager")

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -33,6 +33,8 @@ type Options struct {
 
 	ApproveWhenNoPolicies bool
 
+	LeaderElectionNamespace string
+
 	zapOptions *zap.Options
 	Log        logr.Logger
 }
@@ -52,6 +54,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) *Options {
 	fs.StringVar(&o.MetricsAddress, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	fs.StringVar(&o.ProbeAddress, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	fs.BoolVar(&o.ApproveWhenNoPolicies, "approve-when-no-policies", false, "When no CertificateRequestPolicies exist in the cluster, approve all requests.")
+	fs.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", "cert-manager", "leader election namespace to use for the controller manager")
 
 	cmd.PersistentFlags().AddGoFlagSet(fs)
 

--- a/pkg/policy/chain_test.go
+++ b/pkg/policy/chain_test.go
@@ -28,18 +28,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	cmpolicy "github.com/cert-manager/policy-approver/pkg/api/v1alpha1"
-
 	test "github.com/cert-manager/policy-approver/test/gen"
 )
 
 func TestEvaluateCertificateRequest(t *testing.T) {
 	tests := map[string]struct {
-		request test.RequestOptions
+		request test.CertificateRequestOptions
 		policy  cmpolicy.CertificateRequestPolicySpec
 		expEl   *field.ErrorList
 	}{
 		"any request with all fields nil shouldn't return error": {
-			request: test.RequestOptions{
+			request: test.CertificateRequestOptions{
 				CommonName: "test",
 				IssuerName: "my-issuer",
 			},
@@ -47,7 +46,7 @@ func TestEvaluateCertificateRequest(t *testing.T) {
 			expEl:  new(field.ErrorList),
 		},
 		"violations should return errors": {
-			request: test.RequestOptions{
+			request: test.CertificateRequestOptions{
 				CommonName: "test",
 				CA:         true,
 				Duration: &metav1.Duration{

--- a/pkg/policy/chain_test.go
+++ b/pkg/policy/chain_test.go
@@ -17,64 +17,60 @@ limitations under the License.
 package policy
 
 import (
-	"crypto"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"net"
-	"net/url"
 	"testing"
 	"time"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	cmpki "github.com/jetstack/cert-manager/pkg/util/pki"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	cmpolicy "github.com/cert-manager/policy-approver/pkg/api/v1alpha1"
+
+	test "github.com/cert-manager/policy-approver/test/gen"
 )
 
 func TestEvaluateCertificateRequest(t *testing.T) {
 	tests := map[string]struct {
-		request requestOptions
+		request test.RequestOptions
 		policy  cmpolicy.CertificateRequestPolicySpec
 		expEl   *field.ErrorList
 	}{
 		"any request with all fields nil shouldn't return error": {
-			request: requestOptions{
-				commonName: "test",
-				issuerName: "my-issuer",
+			request: test.RequestOptions{
+				CommonName: "test",
+				IssuerName: "my-issuer",
 			},
 			policy: cmpolicy.CertificateRequestPolicySpec{},
 			expEl:  new(field.ErrorList),
 		},
 		"violations should return errors": {
-			request: requestOptions{
-				commonName: "test",
-				ca:         true,
-				duration: &metav1.Duration{
+			request: test.RequestOptions{
+				CommonName: "test",
+				CA:         true,
+				Duration: &metav1.Duration{
 					Duration: time.Hour * 100,
 				},
-				dnsNames: []string{
+				DNSNames: []string{
 					"foo.bar",
 					"example.com",
 				},
-				ips: []net.IP{
+				IPs: []net.IP{
 					net.ParseIP("1.2.3.4"),
 				},
-				uris: []string{
+				URIs: []string{
 					"hello.world",
 				},
-				keyAlgorithm: x509.RSA,
-				issuerName:   "my-issuer",
-				issuerKind:   "my-kind",
-				issuerGroup:  "my-group",
+				KeyAlgorithm: x509.RSA,
+				IssuerName:   "my-issuer",
+				IssuerKind:   "my-kind",
+				IssuerGroup:  "my-group",
 			},
 			policy: cmpolicy.CertificateRequestPolicySpec{
-				AllowedCommonName: stringPtr("not-test"),
-				AllowedIsCA:       boolPtr(false),
+				AllowedCommonName: test.StringPtr("not-test"),
+				AllowedIsCA:       test.BoolPtr(false),
 				MinDuration: &metav1.Duration{
 					Duration: time.Hour * 200,
 				},
@@ -88,7 +84,7 @@ func TestEvaluateCertificateRequest(t *testing.T) {
 					"world.hello",
 				},
 				AllowedPrivateKey: &cmpolicy.PolicyPrivateKey{
-					AllowedAlgorithm: algPtr(cmapi.ECDSAKeyAlgorithm),
+					AllowedAlgorithm: test.AlgPtr(cmapi.ECDSAKeyAlgorithm),
 				},
 				AllowedIssuers: &[]cmmeta.ObjectReference{
 					{
@@ -111,113 +107,20 @@ func TestEvaluateCertificateRequest(t *testing.T) {
 		},
 	}
 
-	for name, test := range tests {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			cr := mustCertificateRequest(t, test.request)
+			cr := test.MustCertificateRequest(t, tc.request)
 
-			el := new(field.ErrorList)
-			evaluateCertificateRequest(el, &cmpolicy.CertificateRequestPolicy{Spec: test.policy}, cr)
+			_, message, _ := evaluateChainChecks(&cmpolicy.CertificateRequestPolicy{Spec: tc.policy}, cr)
 
-			if !apiequality.Semantic.DeepEqual(el, test.expEl) {
-				t.Errorf("unexpected error, exp=%v got=%v",
-					test.expEl, el)
+			expectedMessage := ""
+			if len(*tc.expEl) > 0 {
+				expectedMessage = tc.expEl.ToAggregate().Error()
+			}
+
+			if message != expectedMessage {
+				t.Errorf("unexpected error, exp=%v got=%v", expectedMessage, message)
 			}
 		})
 	}
-}
-
-type requestOptions struct {
-	issuerName, issuerKind, issuerGroup string
-
-	duration     *metav1.Duration
-	commonName   string
-	dnsNames     []string
-	ips          []net.IP
-	uris         []string
-	keyAlgorithm x509.PublicKeyAlgorithm
-	ca           bool
-}
-
-func mustCertificateRequest(t *testing.T, opts requestOptions) *cmapi.CertificateRequest {
-	var parsedURIs []*url.URL
-	for _, uri := range opts.uris {
-		parsed, err := url.Parse(uri)
-		if err != nil {
-			t.Fatal(err)
-		}
-		parsedURIs = append(parsedURIs, parsed)
-	}
-
-	var sk crypto.Signer
-	var signatureAlgorithm x509.SignatureAlgorithm
-	var err error
-
-	if opts.keyAlgorithm == 0 {
-		opts.keyAlgorithm = x509.RSA
-	}
-
-	switch opts.keyAlgorithm {
-	case x509.RSA:
-		sk, err = cmpki.GenerateRSAPrivateKey(2048)
-		if err != nil {
-			t.Fatal(err)
-		}
-		signatureAlgorithm = x509.SHA256WithRSA
-	case x509.ECDSA:
-		sk, err = cmpki.GenerateECPrivateKey(cmpki.ECCurve256)
-		if err != nil {
-			t.Fatal(err)
-		}
-		signatureAlgorithm = x509.ECDSAWithSHA256
-	default:
-		t.Fatalf("unrecognised key algorithm: %s", err)
-	}
-
-	csr := &x509.CertificateRequest{
-		Version:            3,
-		SignatureAlgorithm: signatureAlgorithm,
-		PublicKeyAlgorithm: opts.keyAlgorithm,
-		PublicKey:          sk.Public(),
-		Subject: pkix.Name{
-			CommonName: opts.commonName,
-		},
-		DNSNames:    opts.dnsNames,
-		IPAddresses: opts.ips,
-		URIs:        parsedURIs,
-	}
-
-	csrBytes, err := cmpki.EncodeCSR(csr, sk)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	csrPEM := pem.EncodeToMemory(&pem.Block{
-		Type: "CERTIFICATE REQUEST", Bytes: csrBytes,
-	})
-
-	return &cmapi.CertificateRequest{
-		Spec: cmapi.CertificateRequestSpec{
-			Duration: opts.duration,
-			Request:  csrPEM,
-			IsCA:     opts.ca,
-			IssuerRef: cmmeta.ObjectReference{
-				Name:  opts.issuerName,
-				Kind:  opts.issuerKind,
-				Group: opts.issuerGroup,
-			},
-		},
-	}
-}
-
-func intPtr(i int) *int {
-	return &i
-}
-func stringPtr(s string) *string {
-	return &s
-}
-func boolPtr(b bool) *bool {
-	return &b
-}
-func algPtr(alg cmapi.PrivateKeyAlgorithm) *cmapi.PrivateKeyAlgorithm {
-	return &alg
 }

--- a/pkg/policy/chain_test.go
+++ b/pkg/policy/chain_test.go
@@ -28,17 +28,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	cmpolicy "github.com/cert-manager/policy-approver/pkg/api/v1alpha1"
-	test "github.com/cert-manager/policy-approver/test/gen"
+	"github.com/cert-manager/policy-approver/test/gen"
 )
 
 func TestEvaluateCertificateRequest(t *testing.T) {
 	tests := map[string]struct {
-		request test.CertificateRequestOptions
+		request gen.CertificateRequestOptions
 		policy  cmpolicy.CertificateRequestPolicySpec
 		expEl   *field.ErrorList
 	}{
 		"any request with all fields nil shouldn't return error": {
-			request: test.CertificateRequestOptions{
+			request: gen.CertificateRequestOptions{
 				CommonName: "test",
 				IssuerName: "my-issuer",
 			},
@@ -46,7 +46,7 @@ func TestEvaluateCertificateRequest(t *testing.T) {
 			expEl:  new(field.ErrorList),
 		},
 		"violations should return errors": {
-			request: test.CertificateRequestOptions{
+			request: gen.CertificateRequestOptions{
 				CommonName: "test",
 				CA:         true,
 				Duration: &metav1.Duration{
@@ -68,8 +68,8 @@ func TestEvaluateCertificateRequest(t *testing.T) {
 				IssuerGroup:  "my-group",
 			},
 			policy: cmpolicy.CertificateRequestPolicySpec{
-				AllowedCommonName: test.StringPtr("not-test"),
-				AllowedIsCA:       test.BoolPtr(false),
+				AllowedCommonName: gen.StringPtr("not-test"),
+				AllowedIsCA:       gen.BoolPtr(false),
 				MinDuration: &metav1.Duration{
 					Duration: time.Hour * 200,
 				},
@@ -83,7 +83,7 @@ func TestEvaluateCertificateRequest(t *testing.T) {
 					"world.hello",
 				},
 				AllowedPrivateKey: &cmpolicy.PolicyPrivateKey{
-					AllowedAlgorithm: test.AlgPtr(cmapi.ECDSAKeyAlgorithm),
+					AllowedAlgorithm: gen.AlgPtr(cmapi.ECDSAKeyAlgorithm),
 				},
 				AllowedIssuers: &[]cmmeta.ObjectReference{
 					{
@@ -106,15 +106,15 @@ func TestEvaluateCertificateRequest(t *testing.T) {
 		},
 	}
 
-	for name, tc := range tests {
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cr := test.MustCertificateRequest(t, tc.request)
+			cr := gen.MustCertificateRequest(t, test.request)
 
-			_, message, _ := evaluateChainChecks(&cmpolicy.CertificateRequestPolicy{Spec: tc.policy}, cr)
+			_, message, _ := evaluateChainChecks(&cmpolicy.CertificateRequestPolicy{Spec: test.policy}, cr)
 
 			expectedMessage := ""
-			if len(*tc.expEl) > 0 {
-				expectedMessage = tc.expEl.ToAggregate().Error()
+			if len(*test.expEl) > 0 {
+				expectedMessage = test.expEl.ToAggregate().Error()
 			}
 
 			if message != expectedMessage {

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -37,7 +37,7 @@ var (
 type evaluatorFn func(policy *cmpolicy.CertificateRequestPolicy, cr *cmapi.CertificateRequest) (bool, string, error)
 
 // loadedEvaluators is a list of different evaluators which will be run during
-// policy evaluation. External packages calling Load will can register their
+// policy evaluation. External packages calling Load will register their
 // evaluatorFn in this list to be used by the client
 var loadedEvaluators = []evaluatorFn{
 	// base evaluatorFn evaluates the checks on fields in

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -19,10 +19,10 @@ package policy
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	authzv1 "k8s.io/api/authorization/v1"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cmpolicy "github.com/cert-manager/policy-approver/pkg/api/v1alpha1"
@@ -34,7 +34,16 @@ var (
 	MissingBindingMessage = "No CertificateRequestPolicies bound"
 )
 
-type evaluatorFn func(el *field.ErrorList, policy *cmpolicy.CertificateRequestPolicy, cr *cmapi.CertificateRequest) error
+type evaluatorFn func(policy *cmpolicy.CertificateRequestPolicy, cr *cmapi.CertificateRequest) (bool, string, error)
+
+// loadedEvaluators is a list of different evaluators which will be run during
+// policy evaluation. External packages calling Load will can register their
+// evaluatorFn in this list to be used by the client
+var loadedEvaluators = []evaluatorFn{
+	// base evaluatorFn evaluates the checks on fields in
+	// CertificateRequestPolicy resources, no external dependency
+	evaluateChainChecks,
+}
 
 // Policy is responsible for evaluating whether incoming CertificateRequests
 // should be approved, checking CertificateRequestPolicys.
@@ -42,14 +51,20 @@ type Policy struct {
 	client.Client
 	approveWhenNoPolicies bool
 
-	evaluator evaluatorFn
+	evaluators []evaluatorFn
+}
+
+// Load can be called in init functions of external evaluator packages to set
+// their evaluatorFns to be run
+func Load(fn evaluatorFn) {
+	loadedEvaluators = append(loadedEvaluators, fn)
 }
 
 func New(client client.Client, approveWhenNoPolicies bool) *Policy {
 	return &Policy{
 		Client:                client,
 		approveWhenNoPolicies: approveWhenNoPolicies,
-		evaluator:             evaluateCertificateRequest,
+		evaluators:            loadedEvaluators,
 	}
 }
 
@@ -115,20 +130,34 @@ func (p *Policy) Evaluate(ctx context.Context, cr *cmapi.CertificateRequest) (bo
 				continue
 			}
 
-			var el field.ErrorList
-			if err := p.evaluator(&el, &crp, cr); err != nil {
-				return false, ErrorMessage, err
+			allEvaluatorsApproved := true
+			var evaluatorMessages []string
+			for _, evaluator := range p.evaluators {
+				approved, message, err := evaluator(&crp, cr)
+				if err != nil {
+					// if a single evaluator fails, then return early without
+					// trying others
+					return false, ErrorMessage, err
+				}
+
+				// messages will only be returned when the CertificateRequest
+				// is not approved
+				evaluatorMessages = append(evaluatorMessages, message)
+
+				// allApprovedApproved will be set to false if any evaluators
+				// do not approve
+				if !approved {
+					allEvaluatorsApproved = false
+				}
 			}
 
-			// If no evaluation errors resulting from this policy, return approved
-			// with the name of the CertificateRequestPolicy.
-			if len(el) == 0 {
+			if allEvaluatorsApproved {
 				return true, fmt.Sprintf("Approved by CertificateRequestPolicy %q", crp.Name), nil
 			}
 
 			// Collect policy errors by the CertificateRequestPolicy name, so errors
 			// can be bubbled to the CertificateRequest condition
-			policyErrors[crp.Name] = el.ToAggregate().Error()
+			policyErrors[crp.Name] = strings.Join(evaluatorMessages, ", ")
 		}
 	}
 

--- a/test/gen/certificaterequests.go
+++ b/test/gen/certificaterequests.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"net"
+	"net/url"
+	"testing"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmpki "github.com/jetstack/cert-manager/pkg/util/pki"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RequestOptions are passed to MustCertificateRequest
+type RequestOptions struct {
+	IssuerName  string
+	IssuerKind  string
+	IssuerGroup string
+
+	Duration     *metav1.Duration
+	CommonName   string
+	DNSNames     []string
+	IPs          []net.IP
+	URIs         []string
+	KeyAlgorithm x509.PublicKeyAlgorithm
+	CA           bool
+}
+
+// MustCertificateRequest will build a cert-manager CertificateRequest with the
+// supplied options for use in test cases
+func MustCertificateRequest(t *testing.T, opts RequestOptions) *cmapi.CertificateRequest {
+	var parsedURIs []*url.URL
+	for _, uri := range opts.URIs {
+		parsed, err := url.Parse(uri)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parsedURIs = append(parsedURIs, parsed)
+	}
+
+	var sk crypto.Signer
+	var signatureAlgorithm x509.SignatureAlgorithm
+	var err error
+
+	if opts.KeyAlgorithm == 0 {
+		opts.KeyAlgorithm = x509.RSA
+	}
+
+	switch opts.KeyAlgorithm {
+	case x509.RSA:
+		sk, err = cmpki.GenerateRSAPrivateKey(2048)
+		if err != nil {
+			t.Fatal(err)
+		}
+		signatureAlgorithm = x509.SHA256WithRSA
+	case x509.ECDSA:
+		sk, err = cmpki.GenerateECPrivateKey(cmpki.ECCurve256)
+		if err != nil {
+			t.Fatal(err)
+		}
+		signatureAlgorithm = x509.ECDSAWithSHA256
+	default:
+		t.Fatalf("unrecognised key algorithm: %s", err)
+	}
+
+	csr := &x509.CertificateRequest{
+		Version:            3,
+		SignatureAlgorithm: signatureAlgorithm,
+		PublicKeyAlgorithm: opts.KeyAlgorithm,
+		PublicKey:          sk.Public(),
+		Subject: pkix.Name{
+			CommonName: opts.CommonName,
+		},
+		DNSNames:    opts.DNSNames,
+		IPAddresses: opts.IPs,
+		URIs:        parsedURIs,
+	}
+
+	csrBytes, err := cmpki.EncodeCSR(csr, sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	csrPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: csrBytes,
+	})
+
+	return &cmapi.CertificateRequest{
+		Spec: cmapi.CertificateRequestSpec{
+			Duration: opts.Duration,
+			Request:  csrPEM,
+			IsCA:     opts.CA,
+			IssuerRef: cmmeta.ObjectReference{
+				Name:  opts.IssuerName,
+				Kind:  opts.IssuerKind,
+				Group: opts.IssuerGroup,
+			},
+		},
+	}
+}

--- a/test/gen/certificaterequests.go
+++ b/test/gen/certificaterequests.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package test
+package gen
 
 import (
 	"crypto"
@@ -31,8 +31,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// RequestOptions are passed to MustCertificateRequest
-type RequestOptions struct {
+// CertificateRequestOptions are passed to MustCertificateRequest
+type CertificateRequestOptions struct {
 	IssuerName  string
 	IssuerKind  string
 	IssuerGroup string
@@ -48,7 +48,7 @@ type RequestOptions struct {
 
 // MustCertificateRequest will build a cert-manager CertificateRequest with the
 // supplied options for use in test cases
-func MustCertificateRequest(t *testing.T, opts RequestOptions) *cmapi.CertificateRequest {
+func MustCertificateRequest(t *testing.T, opts CertificateRequestOptions) *cmapi.CertificateRequest {
 	var parsedURIs []*url.URL
 	for _, uri := range opts.URIs {
 		parsed, err := url.Parse(uri)

--- a/test/gen/utils.go
+++ b/test/gen/utils.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+)
+
+func IntPtr(i int) *int {
+	return &i
+}
+func StringPtr(s string) *string {
+	return &s
+}
+func BoolPtr(b bool) *bool {
+	return &b
+}
+func AlgPtr(alg cmapi.PrivateKeyAlgorithm) *cmapi.PrivateKeyAlgorithm {
+	return &alg
+}

--- a/test/gen/utils.go
+++ b/test/gen/utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package test
+package gen
 
 import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"


### PR DESCRIPTION
Makes policy evaluation extensible for out-of-tree evaluator drop-ins.