### PR TITLE
Move all  main.go logic into `/cmd/app`

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -18,8 +18,10 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
@@ -27,14 +29,21 @@ import (
 	"github.com/cert-manager/policy-approver/pkg/api"
 	"github.com/cert-manager/policy-approver/pkg/controllers"
 	"github.com/cert-manager/policy-approver/pkg/policy"
-	"github.com/spf13/cobra"
 )
 
 const (
 	helpOutput = "A cert-manager policy approver which bases decisions on CertificateRequestPolicies"
 )
 
-func NewCommand(ctx context.Context) *cobra.Command {
+func ExecutePolicyApprover() {
+	cmd := newCommand(ctrl.SetupSignalHandler())
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func newCommand(ctx context.Context) *cobra.Command {
 	opts := new(options.Options)
 
 	cmd := &cobra.Command{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,47 +17,20 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/cert-manager/policy-approver/cmd/app"
 )
 
 func main() {
-	ctx := signalHandler()
+	ctx := ctrl.SetupSignalHandler()
 	cmd := app.NewCommand(ctx)
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-}
-
-func signalHandler() context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	ch := make(chan os.Signal, 2)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	log := zap.New()
-
-	go func() {
-		sig := <-ch
-
-		cancel()
-
-		for i := 0; i < 3; i++ {
-			log.Info("received signal, shutting down gracefully...", "signal", sig.String())
-			sig = <-ch
-		}
-
-		log.Info("received signal, force closing", "signal", sig.String())
-
-		os.Exit(1)
-	}()
-
-	return ctx
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,20 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-	"os"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	"github.com/cert-manager/policy-approver/cmd/app"
 )
 
 func main() {
-	ctx := ctrl.SetupSignalHandler()
-	cmd := app.NewCommand(ctx)
-
-	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
+	app.ExecutePolicyApprover()
 }


### PR DESCRIPTION
This is to make the main package as slim as possible. External projects now can execute the full command directly without importing main.

Use controller-runtime signal handler.

/assign @charlieegan3 